### PR TITLE
fix: change LICENSE to use the team name instead of individual names

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024, Orix Au Yeung, Marco Bravo, Atabak Alishiri, Shawn Hu
+Copyright (c) 2024, VisuMorph authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Changing the name on LICENSE as the list of contributors is already listed on `README.md`. Changing to use the team/project's name to avoid discrepancy.

Closes #5.

edit: typo