### PR TITLE
Change the installation instruction to use PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,17 +27,10 @@ In alphabetical order:
 
 ## Installation
 
-Currently, this package is not published on PyPI. Installation would be for 
-development purposes only.
-
-To install, we recommend to use conda to create a separate environment:
+Currently, the package is published on PyPI. To install the package, run the following command:
 
 ```bash
-git clone https://github.com/UBC-MDS/VisuMorph.git && \
-cd VisuMorph && \
-conda env create -f environment.yml -y && \
-conda activate visumorph && \
-poetry install
+pip install visumorph
 ```
 
 ## Features

--- a/environment.yml
+++ b/environment.yml
@@ -1,8 +1,0 @@
-name: visumorph
-channels:
-  - conda-forge
-  - defaults
-  - anaconda
-dependencies:
-  - poetry=1.7.1
-  - python=3.11


### PR DESCRIPTION
This PR changes the installation instruction written in `README.md` to use `pip` as now we have published the package on PyPI. `environment.yaml` used to create conda environment for installing `poetry` is also being removed.

Closes #76.