### PR TITLE
fix: `Image.__repr__()` pointing to nonexistent property

### DIFF
--- a/src/visumorph/Image.py
+++ b/src/visumorph/Image.py
@@ -24,7 +24,7 @@ class Image:
         pil_image.save(file_path)
 
     def __repr__(self):
-        return f"VisuMorph Image, dimensions: {self.dimensions}"
+        return f"VisuMorph Image, dimensions: {self.get_dimensions()}"
 
 
 def load_image(image_path):

--- a/tests/test_Image.py
+++ b/tests/test_Image.py
@@ -19,3 +19,9 @@ def test_loaded_image_should_have_same_matrix_as_pillow_images():
     vm_img = load_image(image_path)
     pil_image = PImage.open(image_path)
     assert (np.array(pil_image) == vm_img.image).all()
+
+
+def test_image_can_print_out_repr_correctly():
+    img = load_image("tests/img/raw/meme.jpg")
+    msg = str(img)
+    assert msg == "VisuMorph Image, dimensions: (414, 552, 3)"


### PR DESCRIPTION
This PR fix a bug where the code errors when trying to printing out a `Image` object. Also added test for the method.

Closes #95.