### PR TITLE
fix: add back missing hyperlinks to GH profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ https://visumorph.readthedocs.io/en/latest/
 ## Contributors
 In alphabetical order:
 
-- Atabak Alishiri (@atabak-alishiri)
-- Orix Au Yeung (@SoloSynth1)
-- Marco Bravo (@Marcony1)
-- Shawn Hu (@shawnhu444)
+- Atabak Alishiri ([@atabak-alishiri](https://github.com/atabak-alishiri))
+- Orix Au Yeung ([@SoloSynth1](https://github.com/SoloSynth1))
+- Marco Bravo ([@Marcony1](https://github.com/Marcony1))
+- Shawn Hu ([@shawnhu444](https://github.cm/shawnhu444))
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ In alphabetical order:
 - Atabak Alishiri ([@atabak-alishiri](https://github.com/atabak-alishiri))
 - Orix Au Yeung ([@SoloSynth1](https://github.com/SoloSynth1))
 - Marco Bravo ([@Marcony1](https://github.com/Marcony1))
-- Shawn Hu ([@shawnhu444](https://github.cm/shawnhu444))
+- Shawn Hu ([@shawnhu444](https://github.com/shawnhu444))
 
 ## Installation
 


### PR DESCRIPTION
Sorry, just noticed that the handle names were not automatically linked.

This PR adds the links back manually.